### PR TITLE
Add Playwright test script for EPAM Client Work page

### DIFF
--- a/tests/epam-client-work.test.ts
+++ b/tests/epam-client-work.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Client Work Page Test', async ({ page }) => {
+  // Navigate to the EPAM homepage
+  await page.goto('https://www.epam.com/');
+
+  // Click on the "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.isVisible('text=Client Work');
+  expect(clientWorkText).toBeTruthy();
+});


### PR DESCRIPTION
This PR adds a Playwright test script that navigates to the EPAM homepage, clicks on the Services menu, clicks the Explore Our Client Work link, and verifies that the Client Work text is visible on the page.